### PR TITLE
Changed quantifiers of match groups

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = function (options) {
         var arrayOfLines = fileContentString.split("\n");
         arrayOfLines.forEach(function (line, i) {
             var lineNumber = i + 1;
-            var importMatcher = /^\s*import\b\s*([a-z|A-Z|\d]*\b)\s*=.*?([a-z|A-Z|\d|]*?)\s*?(;{0,1})\s*?$/;
+            var importMatcher = /^\s*import\b\s*([a-z|A-Z|\d]+\b)\s*=.*?([a-z|A-Z|\d|]+)\s*?(;{0,1})\s*?$/;
             if (importMatcher.test(line)) {
                 var importMatch = line.match(importMatcher);
                 //get Import Name


### PR DESCRIPTION
Match groups must consist of one or more characters ('+'-quantifier), was 0 or more before ('*'.quantifier).

(current regex would match "import = ;", or "import a = a." etc.)
